### PR TITLE
Raw pointers over shared_ptr

### DIFF
--- a/examples/demo.hpp
+++ b/examples/demo.hpp
@@ -10,7 +10,8 @@ namespace demo
 class state_one : public mobius::state
 {
 public:
-  state_one(std::shared_ptr<mobius::engine> engine);
+  //state_one(std::shared_ptr<engine> engine);
+  state_one(mobius::engine *engine);
 
   void enter();
   void handle_input(int ch);
@@ -18,7 +19,7 @@ public:
   void exit();
 };
 
-state_one::state_one(std::shared_ptr<mobius::engine> engine)
+state_one::state_one(mobius::engine *engine)
 {
   this->state_engine_ = engine;
 }
@@ -48,7 +49,7 @@ void state_one::exit()
 class state_two : public mobius::state
 {
 public:
-  state_two(std::shared_ptr<mobius::engine> engine);
+  state_two(mobius::engine *engine);
 
   void enter();
   void handle_input(int ch);
@@ -56,7 +57,7 @@ public:
   void exit();
 };
 
-state_two::state_two(std::shared_ptr<mobius::engine> engine)
+state_two::state_two(mobius::engine *engine)
 {
   this->state_engine_ = engine;
 }

--- a/include/state.hpp
+++ b/include/state.hpp
@@ -23,7 +23,8 @@ public:
   virtual void exit() = 0;
 
 protected:
-  std::shared_ptr<engine> state_engine_;
+  //std::shared_ptr<engine> state_engine_;
+  engine *state_engine_;
 };
 
 } // namespace mobius

--- a/include/state_engine.hpp
+++ b/include/state_engine.hpp
@@ -5,6 +5,8 @@
 
 #include "state.hpp"
 
+#include <iostream>
+
 namespace mobius
 {
 
@@ -23,7 +25,8 @@ public:
   template<typename state_t, typename = std::enable_if_t<std::is_base_of_v<mobius::state, state_t>>>
   void push()
   {
-    auto state_ptr = std::make_unique<state_t>(this->shared_from_this());
+    //auto state_ptr = std::make_unique<state_t>(this->shared_from_this());
+    auto state_ptr = std::make_unique<state_t>(this);
 
     state_ptr->enter();
 
@@ -86,6 +89,16 @@ public:
   logic_t& logic()
   {
     return this->logic_;
+  }
+
+  template<typename state_t, typename = std::enable_if_t<std::is_base_of_v<mobius::state, state_t>>>
+  void push()
+  {
+    auto state_ptr = std::make_unique<state_t>(this); //->shared_from_this());
+
+    state_ptr->enter();
+
+    this->states_.push_back(std::move(state_ptr));
   }
 };
 

--- a/main.cpp
+++ b/main.cpp
@@ -44,5 +44,7 @@ int main()
 
   std::cout << "Internal logic vector now has size: " << another_engine->logic().size() << '\n'; // Internal logic vector now has size: 3
 
+  another_engine->push<demo::state_one>();
+
   return 0;
 }


### PR DESCRIPTION
Using a shared_ptr to the engine in the state class breaks when using the enhanced_engine. It generates a bad_weak_ptr error. I think this is due to issues around shared_from_this() in derived classes. There's probably a way to fix this, but for now reverting to raw pointers works...